### PR TITLE
fix(src/value): invalid ty_len for tuple

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -84,7 +84,10 @@ impl<'a> Value<'a> {
                 (0..len).fold(prefix_size, |c, _| c + self.ty_len(&data[c..], ty_id))
             }
             TypeDef::Array(a) => a.len().try_into().unwrap(),
-            TypeDef::Tuple(t) => t.fields().len(),
+            TypeDef::Tuple(t) => t
+                .fields()
+                .iter()
+                .fold(0, |c, f| c + self.ty_len(&data[c..], f.id())),
             TypeDef::Compact(_) => compact_len(data),
             TypeDef::BitSequence(_) => unimplemented!(),
         }


### PR DESCRIPTION
When querying for the `ty_len` of `TypeDef::Tuple`, was getting the lenght of the fields within the tuple, instead of the sum of lengths of fields within tuple. Thus leading to copy the incorrect amount of bytes for the tuple itself.

This PR aims to fix this issue, by taking the entire size of the inner fields within it, and summing it up.